### PR TITLE
Correção macros em UTF-8

### DIFF
--- a/seus-dados.tex
+++ b/seus-dados.tex
@@ -1,3 +1,5 @@
+\RequirePackage[utf8]{inputenc}
+
 % Insira aqui seus dados
 
 % seu nome


### PR DESCRIPTION
Adiciona a importação do pacote para uso de UTF-8 no arquivo de definição de macros

Dependendo do compilador ou plataforma utilizados (no caso estava usando Overleaf com pdfLaTeX), caracteres com acentuação definidos nas macros do arquivo [seus-dados.tex](https://github.com/UFSCar/relatorio-estagio/blob/518b0f6b495bdfbdb62d25f62a10ce6bad7bb5b8/seus-dados.tex) eram ignorados, como por exemplo o "á" em "estágio"